### PR TITLE
Add and Remove Functionality W/O Constructor Change

### DIFF
--- a/src/apparmor_file_rule.cc
+++ b/src/apparmor_file_rule.cc
@@ -15,6 +15,16 @@ std::string AppArmor::FileRule::getFilemode() const
   return model->getFilemode();
 }
 
+uint64_t AppArmor::FileRule::getStartPosition() const
+{
+  return model->getStartPosition();
+}
+
+uint64_t AppArmor::FileRule::getEndPosition() const
+{
+  return model->getStopPosition();
+}
+
 bool AppArmor::FileRule::operator==(const AppArmor::FileRule& that) const
 {
   return (that.getFilename() == this->getFilename()) && 

--- a/src/apparmor_file_rule.hh
+++ b/src/apparmor_file_rule.hh
@@ -14,6 +14,8 @@ namespace AppArmor {
 
       std::string getFilename() const;
       std::string getFilemode() const;
+      uint64_t getStartPosition() const;
+      uint64_t getEndPosition() const;
 
       // Whether or not two FileRule objects are equal
       bool operator==(const AppArmor::FileRule& that) const;

--- a/src/apparmor_parser.cc
+++ b/src/apparmor_parser.cc
@@ -11,8 +11,6 @@
 #include <fstream>
 #include <cstdio>
 
-std::string trim(const std::string& str);
-
 /**
  * Idea: change constructor to take a file path as an argument rather than ifstream.
  * Create ifstream within constructor
@@ -50,7 +48,7 @@ std::list<AppArmor::Profile> AppArmor::Parser::getProfileList() const
     return profile_list;
 }
 
-bool removeRule(std::string path, AppArmor::Profile profile, AppArmor::FileRule fileRule) 
+AppArmor::Parser removeRule(std::string path, AppArmor::Profile profile, AppArmor::FileRule fileRule) 
 {
     std::string line {};
     std::string profileName = profile.name();
@@ -65,7 +63,7 @@ bool removeRule(std::string path, AppArmor::Profile profile, AppArmor::FileRule 
         if (!foundProfile && (line.compare(profileName + " {") == 0 || line.compare("profile " + profileName + " {") == 0)) {
             foundProfile = true;
         } else if(foundProfile && line.compare("}") == 0){
-            return false;
+            throw "Rule not found in profile!";
         }
 
         // Trim the leading whitespace and trailing whitespace for inside the profile braces.
@@ -73,11 +71,13 @@ bool removeRule(std::string path, AppArmor::Profile profile, AppArmor::FileRule 
 
         if (foundProfile && line.compare(ruleName + " " + ruleNode + ",") == 0) {
             removeRuleFromFile(path, profileName, line);
-            return true;
+            std::ifstream stream(path, std::ios::in);
+            AppArmor::Parser parser(stream);
+            return parser;
         }
     }
 
-    return false;
+    throw "Profile not found!";
 }
 
 // Helper function for removeRule

--- a/src/apparmor_parser.cc
+++ b/src/apparmor_parser.cc
@@ -3,11 +3,14 @@
 #include "parser/lexer.hh"
 #include "parser/tree/ParseTree.hh"
 
+#include <iostream>
 #include <memory>
 #include <parser_yacc.hh>
 #include <string>
 #include <iostream>
 #include <fstream>
+
+std::string trim(const std::string& str);
 
 /**
  * Idea: change constructor to take a file path as an argument rather than ifstream.
@@ -50,24 +53,54 @@ bool AppArmor::Parser::removeRule(std::string path, std::string profileName, std
 std::string ruleMode) 
 {
     std::string line {};
-    std::fstream file(path, std::ios::out);
+    std::fstream file(path, std::ios::in);
     bool foundProfile = false;
 
     while(std::getline(file, line)){
         // Find the matching profile
         if (line.compare(profileName + " {") == 0 || line.compare("profile " + profileName + " {") == 0) {
+            std::cout << "Found profile at: " << line << "\n";
             foundProfile = true;
-        } else if(line.compare("}")){
+        } else if(line.compare("}") == 0){
             foundProfile = false;
         }
 
-        //Find the matching rule
-        if (line.compare(ruleName + " " + ruleMode + ",") == 0 && foundProfile) {
-            // the bastardline
-            line.replace(0, ruleName.length() + ruleMode.length() + 2, "");
+        // Trim the leading whitespace and trailing whitespace for inside the profile braces.
+        line = trim(line);
+
+        if (foundProfile && line.compare(ruleName + " " + ruleMode + ",") == 0) {
+            std::cout << "REMOVING RULE! Found rule at: " << line << "\n";
+            
+            /* Note: We will most likely need to rewrite the file. Unfortuantely, C++ doesn't provide an easy way to replace strings in a file.
+                     Due to this, it is recommended to read the file, find the text we want to replace, and write back everything except for
+                     that line to a new file. We can then rename the file so that the old one will be replaced.*/
+
+            //line.replace(0, ruleName.length() + ruleMode.length() + 2, "");
             return true;
         }
     }
 
     return false;
+}
+
+// Trims leading and trailing whitespace
+std::string trim(const std::string& str)
+{
+
+    const std::string& whitespace = " \t";
+
+    // Find the character that isn't whitespace.
+    const auto strBegin = str.find_first_not_of(whitespace);
+
+    // If it cannot find it, then return an empty string.
+    if (strBegin == std::string::npos)
+        return ""; // no content
+
+    // Find the last character that isn't whitespace.
+    const auto strEnd = str.find_last_not_of(whitespace);
+
+    // Remove the white space.
+    const auto strRange = strEnd - strBegin + 1;
+
+    return str.substr(strBegin, strRange);
 }

--- a/src/apparmor_parser.cc
+++ b/src/apparmor_parser.cc
@@ -5,7 +5,15 @@
 
 #include <memory>
 #include <parser_yacc.hh>
+#include <string>
+#include <iostream>
+#include <fstream>
 
+/**
+ * Idea: change constructor to take a file path as an argument rather than ifstream.
+ * Create ifstream within constructor
+ * Create ofstream within remove function
+*/
 AppArmor::Parser::Parser(std::ifstream &stream)
 {
     Driver driver;
@@ -36,4 +44,30 @@ void AppArmor::Parser::initializeProfileList(std::shared_ptr<ParseTree> ast)
 std::list<AppArmor::Profile> AppArmor::Parser::getProfileList() const
 {
     return profile_list;
+}
+
+bool AppArmor::Parser::removeRule(std::string path, std::string profileName, std::string ruleName, 
+std::string ruleMode) 
+{
+    std::string line {};
+    std::fstream file(path, std::ios::out);
+    bool foundProfile = false;
+
+    while(std::getline(file, line)){
+        // Find the matching profile
+        if (line.compare(profileName + " {") == 0 || line.compare("profile " + profileName + " {") == 0) {
+            foundProfile = true;
+        } else if(line.compare("}")){
+            foundProfile = false;
+        }
+
+        //Find the matching rule
+        if (line.compare(ruleName + " " + ruleMode + ",") == 0 && foundProfile) {
+            // the bastardline
+            line.replace(0, ruleName.length() + ruleMode.length() + 2, "");
+            return true;
+        }
+    }
+
+    return false;
 }

--- a/src/apparmor_parser.hh
+++ b/src/apparmor_parser.hh
@@ -7,8 +7,6 @@
 #include <list>
 #include <string>
 
-
-void removeRuleFromFile(const std::string& path, const std::string& profile, const std::string& remove);
 std::string trim(const std::string& str);
 
 class ParseTree;
@@ -19,6 +17,8 @@ namespace AppArmor {
       Parser(std::ifstream &stream);
 
       std::list<Profile> getProfileList() const;
+      AppArmor::Parser removeRule(std::string path, AppArmor::Profile profile, AppArmor::FileRule fileRule);
+      AppArmor::Parser addRule(std::string path, AppArmor::Profile profile, const std::string& fileRule, std::string& fileMode);
 
     private:
       void initializeProfileList(std::shared_ptr<ParseTree> ast);
@@ -27,7 +27,5 @@ namespace AppArmor {
       std::list<Profile> profile_list; 
   };
 }
-
-AppArmor::Parser removeRule(std::string path, AppArmor::Profile profile, AppArmor::FileRule fileRule);
 
 #endif // APPARMOR_PARSER_HH

--- a/src/apparmor_parser.hh
+++ b/src/apparmor_parser.hh
@@ -8,6 +8,8 @@
 #include <string>
 
 
+bool removeRule(std::string path, AppArmor::Profile profile, AppArmor::FileRule fileRule);
+void removeRuleFromFile(const std::string& path, const std::string& profile, const std::string& remove);
 std::string trim(const std::string& str);
 
 class ParseTree;
@@ -19,11 +21,8 @@ namespace AppArmor {
 
       std::list<Profile> getProfileList() const;
 
-      bool removeRule(std::string path, std::string profileName, std::string ruleName, std::string ruleMode);
-
     private:
       void initializeProfileList(std::shared_ptr<ParseTree> ast);
-      void removeRuleFromFile(const std::string& path, const std::string& profile, const std::string& remove);
       std::string path;
 
       std::list<Profile> profile_list; 

--- a/src/apparmor_parser.hh
+++ b/src/apparmor_parser.hh
@@ -8,7 +8,6 @@
 #include <string>
 
 
-bool removeRule(std::string path, AppArmor::Profile profile, AppArmor::FileRule fileRule);
 void removeRuleFromFile(const std::string& path, const std::string& profile, const std::string& remove);
 std::string trim(const std::string& str);
 
@@ -28,5 +27,7 @@ namespace AppArmor {
       std::list<Profile> profile_list; 
   };
 }
+
+AppArmor::Parser removeRule(std::string path, AppArmor::Profile profile, AppArmor::FileRule fileRule);
 
 #endif // APPARMOR_PARSER_HH

--- a/src/apparmor_parser.hh
+++ b/src/apparmor_parser.hh
@@ -5,6 +5,7 @@
 
 #include <fstream>
 #include <list>
+#include <string>
 
 class ParseTree;
 
@@ -15,8 +16,11 @@ namespace AppArmor {
 
       std::list<Profile> getProfileList() const;
 
+      bool removeRule(std::string path, std::string profileName, std::string ruleName, std::string ruleMode);
+
     private:
       void initializeProfileList(std::shared_ptr<ParseTree> ast);
+      std::string path;
 
       std::list<Profile> profile_list; 
   };

--- a/src/apparmor_parser.hh
+++ b/src/apparmor_parser.hh
@@ -7,6 +7,9 @@
 #include <list>
 #include <string>
 
+
+std::string trim(const std::string& str);
+
 class ParseTree;
 
 namespace AppArmor {
@@ -20,6 +23,7 @@ namespace AppArmor {
 
     private:
       void initializeProfileList(std::shared_ptr<ParseTree> ast);
+      void removeRuleFromFile(const std::string& path, const std::string& profile, const std::string& remove);
       std::string path;
 
       std::list<Profile> profile_list; 


### PR DESCRIPTION
This code has implement the official versions of the add and remove functionality without changing any of the base constructor code with the stream. This implementation has the user pass in the path of the profile. For full add, edit, and remove functionality with changes so that the user does not need to put in the path variable, please see Madison Field's repository.