### PR TITLE
Remove some extraneous code

### DIFF
--- a/src/parser/lib.c
+++ b/src/parser/lib.c
@@ -21,11 +21,8 @@
 
 #include <ctype.h>
 #include <stdbool.h>
-#include <stdint.h>
 #include <string.h>
 
-#include <sys/stat.h>
-#include <sys/types.h>
 
 //NOLINTBEGIN
 /**

--- a/src/parser/parser.cc
+++ b/src/parser/parser.cc
@@ -37,16 +37,6 @@
 #include "lexer.hh"
 
 // NOLINTBEGIN
-/* #define DEBUG */
-#ifdef DEBUG
-#undef PDEBUG
-#define PDEBUG(fmt, args...) fprintf(stderr, "Lexer: " fmt, ## args)
-#else
-#undef PDEBUG
-#define PDEBUG(fmt, args...)	/* Do nothing */
-#endif
-#define NPDEBUG(fmt, args...)	/* Do nothing */
-
 struct keyword_table {
 	const char *keyword;
 	unsigned int token;
@@ -135,32 +125,27 @@ static struct keyword_table rlimit_table[] = {
 };
 
 /* for alpha matches, check for keywords */
-static int get_table_token(const char *name unused, struct keyword_table *table,
+static int get_table_token(struct keyword_table *table,
 			   const char *keyword)
 {
 	int i;
-
 	for (i = 0; table[i].keyword; i++) {
-		PDEBUG("Checking %s %s\n", name, table[i].keyword);
 		if (strcmp(keyword, table[i].keyword) == 0) {
-			PDEBUG("Found %s %s\n", name, table[i].keyword);
 			return table[i].token;
 		}
 	}
-
-	PDEBUG("Unable to find %s %s\n", name, keyword);
 	return -1;
 }
 
 /* for alpha matches, check for keywords */
 int get_keyword_token(const char *keyword)
 {
-	return get_table_token("keyword", keyword_table, keyword);
+	return get_table_token(keyword_table, keyword);
 }
 
 int get_rlimit(const char *name)
 {
-	return get_table_token("rlimit", rlimit_table, name);
+	return get_table_token(rlimit_table, name);
 }
 
 char *processunquoted(const char *string, int len)

--- a/src/parser/parser.cc
+++ b/src/parser/parser.cc
@@ -21,16 +21,7 @@
 /* assistance routines */
 
 #include <cassert>
-#include <cctype>
-#include <cstdarg>
-#include <cstdio>
-#include <cstdlib>
 #include <cstring>
-#include <fcntl.h>
-#include <linux/capability.h>
-#include <sys/stat.h>
-#include <sys/types.h>
-#include <unistd.h>
 
 #include "lib.h"
 #include "common.hh"

--- a/src/parser/parser.h
+++ b/src/parser/parser.h
@@ -191,38 +191,8 @@ enum ExecMode {
   EXEC_MODE_SAFE = 2
 };
 
-#ifdef DEBUG
-#define PDEBUG(fmt, args...)				\
-do {							\
-	int pdebug_error = errno;			\
-	fprintf(stderr, "parser: " fmt, ## args);	\
-	errno = pdebug_error;				\
-} while (0)
-#else
-#define PDEBUG(fmt, args...)	/* Do nothing */
-#endif
-#define NPDEBUG(fmt, args...)	/* Do nothing */
-
-#define PERROR(fmt, args...)			\
-do {						\
-	int perror_error = errno;		\
-	fprintf(stderr, fmt, ## args);		\
-	errno = perror_error;			\
-} while (0)
-
-#ifndef TRUE
-#define TRUE	(1)
-#endif
-#ifndef FALSE
-#define FALSE	(0)
-#endif
-
 #define MIN_PORT 0
 #define MAX_PORT 65535
-
-#ifndef unused
-#define unused __attribute__ ((unused))
-#endif
 
 /* provided by parser_lex.l */
 extern int yyparse(void);

--- a/src/parser/parser.h
+++ b/src/parser/parser.h
@@ -22,21 +22,11 @@
 #ifndef __AA_PARSER_H
 #define __AA_PARSER_H
 
-#include <endian.h>
 #include <stdint.h>
-#include <string.h>
 #include <sys/resource.h>
 
 #include <libintl.h>
 #define _(s) gettext(s)
-
-#define MODULE_NAME "apparmor"
-
-/* Global variable to pass token to lexer.  Will be replaced by parameter
- * when lexer and parser are made reentrant
- */
-// extern int parser_token;
-
 
 #define WARN_RULE_NOT_ENFORCED	0x1
 #define WARN_RULE_DOWNGRADED	0x2


### PR DESCRIPTION
This fixes #9 by removing the macro that was creating a compilation error.

I also removed some additional code and includes that were leftover from [apparmor_parser](https://gitlab.com/apparmor/apparmor/-/tree/master/parser). Hopefully this will make the code simpler and easier to read.